### PR TITLE
Make RemovePermissionIdFields migration reversible

### DIFF
--- a/db/migrate/20150325173027_remove_permission_id_fields.rb
+++ b/db/migrate/20150325173027_remove_permission_id_fields.rb
@@ -1,6 +1,6 @@
 class RemovePermissionIdFields < ActiveRecord::Migration
   def change
-    remove_column :roles, :permission_id
-    remove_column :users, :permission_id
+    remove_column :roles, :permission_id, :integer
+    remove_column :users, :permission_id, :integer
   end
 end


### PR DESCRIPTION
In order for `remove_column` to be reversible the type needs to be supplied.