### PR TITLE
Add uid to User

### DIFF
--- a/db/migrate/20150330085857_enable_uuid_ossp_extension.rb
+++ b/db/migrate/20150330085857_enable_uuid_ossp_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidOsspExtension < ActiveRecord::Migration
+  def change
+    enable_extension "uuid-ossp"
+  end
+end

--- a/db/migrate/20150330090025_add_uid_to_users.rb
+++ b/db/migrate/20150330090025_add_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUidToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :uid, :uuid, default: "uuid_generate_v4()"
+  end
+end


### PR DESCRIPTION
* This adds an `uid` field to each User, relying on Postgres to
insert an auto-generated uuid on record save