### PR TITLE
Add User credentials endpoint

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -9,5 +9,13 @@ module Api::V1
     def current_resource_owner
       User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
     end
+
+    def doorkeeper_unauthorized_render_options
+      {
+        json: {
+          errors: ["Not authorized, please login"]
+        }
+      }
+    end
   end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,13 @@
+module Api::V1
+  class ApiController < ApplicationController
+    protect_from_forgery with: :null_session
+    skip_before_action :authenticate_user!
+    before_action :doorkeeper_authorize!
+
+    private
+
+    def current_resource_owner
+      User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+    end
+  end
+end

--- a/app/controllers/api/v1/credentials_controller.rb
+++ b/app/controllers/api/v1/credentials_controller.rb
@@ -1,0 +1,9 @@
+module Api::V1
+  class CredentialsController < ApiController
+    respond_to :json
+
+    def show
+      render json: CredentialsSerializer.new(current_resource_owner).call
+    end
+  end
+end

--- a/app/models/null_profile.rb
+++ b/app/models/null_profile.rb
@@ -1,0 +1,25 @@
+class NullProfile
+  def address
+    ""
+  end
+
+  def email
+    ""
+  end
+
+  def name
+    ""
+  end
+
+  def organisations
+    Organisation.none
+  end
+
+  def postcode
+    ""
+  end
+
+  def tel
+    ""
+  end
+end

--- a/app/serializers/credentials_serializer.rb
+++ b/app/serializers/credentials_serializer.rb
@@ -1,0 +1,50 @@
+class CredentialsSerializer
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    serialize_credentials
+  end
+
+  private
+
+  attr_reader :user
+
+  def serialize_credentials
+    {
+      user: serialized_user,
+      profile: serialized_profile,
+      roles: serialized_roles,
+    }.to_json
+  end
+
+  def serialized_user
+    {
+      id: user.id,
+      email: user.email,
+      uid: user.uid,
+    }
+  end
+
+  def serialized_profile
+    {
+      email: profile.email,
+      name:  profile.name,
+      telephone: profile.tel,
+      address: {
+        full_address: profile.address,
+        postcode: profile.postcode,
+      },
+      organisation_ids: profile.organisations.pluck(:id)
+    }
+  end
+
+  def serialized_roles
+    user.roles.pluck(:name)
+  end
+
+  def profile
+    user.profile || NullProfile.new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,12 @@ Rails.application.routes.draw do
 
   root 'welcome#index'
 
+  namespace :api do
+    namespace :v1 do
+      get "/me", to: "credentials#show"
+    end
+  end
+
   get '/status' => 'status#index'
   get '/help', controller: :static, action: :help, as: :help
   get '/maintenance', controller: :static, action: :maintenance, as: :maintenance

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20150330094216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "government_applications", force: :cascade do |t|
     t.string   "oauth_application_id"
@@ -109,18 +110,19 @@ ActiveRecord::Schema.define(version: 20150330094216) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",                   null: false
+    t.string   "encrypted_password",     default: "",                   null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,                    null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.uuid     "uid",                    default: "uuid_generate_v4()"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/doorkeeper_factories.rb
+++ b/spec/factories/doorkeeper_factories.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :access_token, class: Doorkeeper::AccessToken do
+    sequence(:resource_owner_id) { |n| n }
+    application
+    expires_in 2.hours
+  end
+
+  factory :application, class: Doorkeeper::Application do
+    sequence(:name) { |n| "Application #{n}" }
+    redirect_uri "https://app.com/callback"
+  end
+end

--- a/spec/factories/government_application.rb
+++ b/spec/factories/government_application.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :government_application
+end

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :permission
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:email)            {|n| "barry#{n}@example.com" }
     user.password               "password"
     user.password_confirmation  "password"
+    user.uid { SecureRandom.uuid }
 
     trait :with_profile do
       association :profile

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -1,33 +1,53 @@
 require "rails_helper"
 
-RSpec.describe 'GET /api/v1/credentials/me ' do
-  it "returns the user credentials" do
-    application = create :application
-    organisation = create :organisation
-    government_application = create :government_application
-    profile = create :profile, organisations: [organisation]
-    role = create :role
-    permissions = create_list(
-      :permission,
-      2,
-      role: role,
-      government_application: government_application,
-      organisation: organisation
-    )
-    user = create :user, profile: profile, permissions: permissions
-    token = create(
-      :access_token,
-      application: application,
-      resource_owner_id: user.id,
-      scopes: "public"
-    )
+RSpec.describe 'GET /api/v1/credentials/me' do
+  context 'with an invalid authentication token' do
+    it 'returns a 401 response with an error message' do
 
-    get "/api/v1/me", nil,
-      {
-      "Authorization": "Bearer #{token.token}",
-      "Content-Type": "application/json"
-    }
+      get "/api/v1/me", nil,
+        {
+          "Authorization": "Bearer foo",
+          "Content-Type": "application/json"
+        }
 
+      expect(response.status).to eq(401)
+      expect(response_json).to eq(
+        {
+          "errors" => ["Not authorized, please login"]
+        }
+      )
+    end
+  end
+
+  context 'with a valid authentication token' do
+    it "returns a 200 response with the user credentials" do
+      application = create :application
+      organisation = create :organisation
+      government_application = create :government_application
+      profile = create :profile, organisations: [organisation]
+      role = create :role
+      permissions = create_list(
+        :permission,
+        2,
+        role: role,
+        government_application: government_application,
+        organisation: organisation
+      )
+      user = create :user, profile: profile, permissions: permissions
+      token = create(
+        :access_token,
+        application: application,
+        resource_owner_id: user.id,
+        scopes: "public"
+      )
+
+      get "/api/v1/me", nil,
+        {
+        "Authorization": "Bearer #{token.token}",
+        "Content-Type": "application/json"
+        }
+
+      expect(response.status).to eq(200)
       expect(response_json).to eq(
         {
           "user" => {
@@ -48,5 +68,6 @@ RSpec.describe 'GET /api/v1/credentials/me ' do
           "roles" => user.roles.map(&:name)
         }
       )
+    end
   end
 end

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe 'GET /api/v1/credentials/me ' do
+  it "returns the user credentials" do
+    application = create :application
+    organisation = create :organisation
+    government_application = create :government_application
+    profile = create :profile, organisations: [organisation]
+    role = create :role
+    permissions = create_list(
+      :permission,
+      2,
+      role: role,
+      government_application: government_application,
+      organisation: organisation
+    )
+    user = create :user, profile: profile, permissions: permissions
+    token = create(
+      :access_token,
+      application: application,
+      resource_owner_id: user.id,
+      scopes: "public"
+    )
+
+    get "/api/v1/me", nil,
+      {
+      "Authorization": "Bearer #{token.token}",
+      "Content-Type": "application/json"
+    }
+
+      expect(response_json).to eq(
+        {
+          "user" => {
+            "id" => user.id,
+            "email" => user.email,
+            "uid" => user.uid
+          },
+          "profile" => {
+            "email" => user.profile.email,
+            "name" => user.profile.name,
+            "telephone" => user.profile.tel,
+            "address" => {
+              "full_address" => user.profile.address,
+              "postcode" => user.profile.postcode,
+            },
+            "organisation_ids" => user.profile.organisations.map(&:id)
+          },
+          "roles" => user.roles.map(&:name)
+        }
+      )
+  end
+end

--- a/spec/serializers/credentials_serializer_spec.rb
+++ b/spec/serializers/credentials_serializer_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe CredentialsSerializer, "#call" do
+  it "serializes the credentials for the passed in user" do
+    profile = build_stubbed :profile
+    user = build_stubbed :user, profile: profile
+
+    serializer = CredentialsSerializer.new user
+
+    expect(serializer.call).to eq(
+      {
+        "user" => {
+          id: user.id,
+          email: user.email,
+          uid: user.uid
+        },
+        "profile" => {
+          "email" => user.profile.email,
+          "name" => user.profile.name,
+          "telephone" => user.profile.tel,
+          "address" => {
+            full_address: user.profile.address,
+            postcode: user.profile.postcode,
+          },
+          "organisation_ids" => user.profile.organisations.map(&:id)
+        },
+        "roles" => user.roles.pluck(:name)
+      }.to_json
+    )
+  end
+
+  it "returns empty profile keys if the user has no profile" do
+    user = build_stubbed :user
+
+    serializer = CredentialsSerializer.new user
+
+    expect(serializer.call).to eq(
+      {
+        "user" => {
+          id: user.id,
+          email: user.email,
+          uid: user.uid
+        },
+        "profile" => {
+          "email" => "",
+          "name" => "",
+          "telephone" => "",
+          "address" => {
+            "full_address" => "",
+            "postcode" => "",
+          },
+          "organisation_ids" => [],
+        },
+        "roles" => []
+      }.to_json
+    )
+  end
+end

--- a/spec/support/response_json.rb
+++ b/spec/support/response_json.rb
@@ -1,0 +1,7 @@
+module ResponseJSON
+  def response_json
+    JSON.parse(response.body)
+  end
+end
+
+RSpec.configure { |config| config.include ResponseJSON }


### PR DESCRIPTION
After the Oauth procedure, we want to return a payload of data that
contains several points of info regarding the user.

This PR sets an `/api/v1/me` route, pointing to
`Api::V1::CredentialsController#show`, returning the required
information.