### PR TITLE
Set test database name in database yml

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 # Database settings
-DS_AUTH_DATABASE_DATABASE=defence-solicitor-service-auth_development
 DS_AUTH_DATABASE_HOST=localhost
 DS_AUTH_DATABASE_PASSWORD=''
 DS_AUTH_DATABASE_USERNAME='postgres'

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 # Database settings
-DS_AUTH_DATABASE_DATABASE=defence-solicitor-service-auth_test
 DS_AUTH_DATABASE_HOST=localhost
 DS_AUTH_DATABASE_PASSWORD=''
 DS_AUTH_DATABASE_USERNAME='postgres'

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,5 @@
 default: &default
   adapter: postgresql
-  database: <%= ENV.fetch("DS_AUTH_DATABASE_DATABASE", nil) %>
   host: <%= ENV.fetch("DS_AUTH_DATABASE_HOST", nil) %>
   password: <%= ENV.fetch("DS_AUTH_DATABASE_PASSWORD", nil) %>
   username: <%= ENV.fetch("DS_AUTH_DATABASE_USERNAME", nil) %>
@@ -8,9 +7,8 @@ default: &default
 
 development:
   <<: *default
+  database: defence-solicitor-service-auth_development
 
 test:
   <<: *default
-
-production:
-  <<: *default
+  database: defence-solicitor-service-auth_test


### PR DESCRIPTION
Setting the db name in .env causes only the creation of the
development database, since rake tasks such as `db:create` are ran by
default in development environment.

This has the consequence of not respecting setup rake tasks,
reproducible by running `rake db:create:all` and noticing the output of
"<db name> development already exists>" in triplicate (one per env).

.env files have also been updated to reflect the change.