### PR TITLE
Organisation UIDs on API

### DIFF
--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -12,7 +12,7 @@ class ProfileSerializer < BaseSerializer
 
   def serialized_links
     {
-      organisation: "/api/v1/organisations/#{object.organisations.first.id}"
+      organisation: "/api/v1/organisations/#{object.organisations.first.uid}"
     }
   end
 end

--- a/spec/requests/api/v1/profiles/index_spec.rb
+++ b/spec/requests/api/v1/profiles/index_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "GET /api/v1/profiles" do
               "name" => "Barry Evans",
               # "type" => another_profile.type,
               "links" => {
-                "organisation" => "/api/v1/organisations/#{organisation.id}"
+                "organisation" => "/api/v1/organisations/#{organisation.uid}"
               }
             },
             {
@@ -30,7 +30,7 @@ RSpec.describe "GET /api/v1/profiles" do
               "name" => "Eamonn Holmes",
               # "type" => users_profile.type,
               "links" => {
-                "organisation" => "/api/v1/organisations/#{organisation.id}"
+                "organisation" => "/api/v1/organisations/#{organisation.uid}"
               }
             }
           ]
@@ -63,7 +63,7 @@ RSpec.describe "GET /api/v1/profiles" do
               "name" => matching_profile.name,
               # "type" => matching_profile.type,
               "links" => {
-                "organisation" => "/api/v1/organisations/#{organisation.id}"
+                "organisation" => "/api/v1/organisations/#{organisation.uid}"
               }
             }
           ]
@@ -86,7 +86,7 @@ RSpec.describe "GET /api/v1/profiles" do
               "name" => "Barry Evans",
               # "type" => match_2.type,
               "links" => {
-                "organisation" => "/api/v1/organisations/#{organisation.id}"
+                "organisation" => "/api/v1/organisations/#{organisation.uid}"
               }
             },
             {
@@ -94,7 +94,7 @@ RSpec.describe "GET /api/v1/profiles" do
               "name" => "Barry Scott",
               # "type" => match_1.type,
               "links" => {
-                "organisation" => "/api/v1/organisations/#{organisation.id}"
+                "organisation" => "/api/v1/organisations/#{organisation.uid}"
               }
             }
           ]

--- a/spec/requests/api/v1/profiles/show_spec.rb
+++ b/spec/requests/api/v1/profiles/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "GET /api/v1/profiles/:uid" do
           "name" => profile.name,
           # "type" => profile.type,
           "links" => {
-            "organisation" => "/api/v1/organisations/#{organisation.id}"
+            "organisation" => "/api/v1/organisations/#{organisation.uid}"
           }
         }
       )

--- a/spec/serializers/profile_serializer_spec.rb
+++ b/spec/serializers/profile_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ProfileSerializer do
           uid: profile.uid,
           name: profile.name,
           links: {
-            organisation: "/api/v1/organisations/#{organisation.id}"
+            organisation: "/api/v1/organisations/#{organisation.uid}"
           }
         }
       )

--- a/spec/serializers/profiles_serializer_spec.rb
+++ b/spec/serializers/profiles_serializer_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe ProfilesSerializer do
             uid: profile_1.uid,
             name: profile_1.name,
             links: {
-              organisation: "/api/v1/organisations/#{organisation.id}"
+              organisation: "/api/v1/organisations/#{organisation.uid}"
             }
           },
           {
             uid: profile_2.uid,
             name: profile_2.name,
             links: {
-              organisation: "/api/v1/organisations/#{organisation.id}"
+              organisation: "/api/v1/organisations/#{organisation.uid}"
             }
           }
         ]


### PR DESCRIPTION
* Switch Profile API endpoints to expose the Organisation UIDs rather than the database IDs, for consistency across the entire API