### PR TITLE
Expose organisation_uids on credentials /me endpoint

### DIFF
--- a/app/serializers/credentials_serializer.rb
+++ b/app/serializers/credentials_serializer.rb
@@ -35,7 +35,7 @@ class CredentialsSerializer
         full_address: profile.address,
         postcode: profile.postcode,
       },
-      organisation_ids: profile.organisations.pluck(:id),
+      organisation_uids: profile.organisations.pluck(:uid),
       uid: profile.uid,
     }
   end

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -9,6 +9,18 @@ FactoryGirl.define do
     uid                         { SecureRandom.uuid }
   end
 
+  trait :with_organisations do
+    transient do
+      number_of_organisations 2
+    end
+
+    after(:create) do |profile, evaluator|
+      (1..evaluator.number_of_organisations).each do
+        create :membership, profile: profile
+      end
+    end
+  end
+
   trait :with_user do
     association :user
   end

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "GET /api/v1/me" do
               "full_address" => user.profile.address,
               "postcode" => user.profile.postcode,
             },
-            "organisation_ids" => user.profile.organisations.map(&:id),
+            "organisation_uids" => user.profile.organisations.map(&:uid),
             "uid" => user.profile.uid
           },
           "roles" => user.roles_for(application: application).map(&:name)

--- a/spec/serializers/credentials_serializer_spec.rb
+++ b/spec/serializers/credentials_serializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CredentialsSerializer do
   end
 
   describe "#serialize" do
-    let(:profile) { build_stubbed :profile }
+    let(:profile) { create :profile, :with_organisations }
     let(:application) { build_stubbed :doorkeeper_application }
     let(:role) { build_stubbed :role }
     let(:permission) { build_stubbed :permission, application: application, user: user, role: role }
@@ -38,7 +38,7 @@ RSpec.describe CredentialsSerializer do
               full_address: user.profile.address,
               postcode: user.profile.postcode,
             },
-            organisation_ids: user.profile.organisations.map(&:id),
+            organisation_uids: user.profile.organisations.map(&:uid),
             uid: user.profile.uid
           },
           roles: user.roles_for(application: application).map(&:name)
@@ -64,7 +64,7 @@ RSpec.describe CredentialsSerializer do
               full_address: "",
               postcode: "",
             },
-            organisation_ids: [],
+            organisation_uids: [],
             uid: ""
           },
           roles: []


### PR DESCRIPTION
* No longer expose organisation_ids, instead expose organisation_uids
* Implements: https://www.pivotaltracker.com/story/show/92603170