### PR TITLE
Don't issue oauth token for unauthorised users

### DIFF
--- a/app/controllers/doorkeeper/authorizations_with_role_check_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_with_role_check_controller.rb
@@ -1,0 +1,26 @@
+module Doorkeeper
+  class AuthorizationsWithRoleCheckController < Doorkeeper::AuthorizationsController
+    def new
+      # current_resource_owner == current_user
+      # server.client_via_uid.application == OAuth::Applications
+      if resource_owner_has_role_for_application?
+        super
+      else
+        redirect_to role_failure_uri
+      end
+    end
+
+    private
+
+    def resource_owner_has_role_for_application?
+      current_resource_owner.permissions.where(application_id: server.client_via_uid.application.id).exists?
+    end
+
+    def role_failure_uri
+      uri = URI.parse server.client_via_uid.redirect_uri
+      uri.path = "/auth/failure"
+      uri.query = "message=unauthorized"
+      uri.to_s
+    end
+  end
+end

--- a/app/controllers/doorkeeper/authorizations_with_role_check_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_with_role_check_controller.rb
@@ -1,8 +1,6 @@
 module Doorkeeper
   class AuthorizationsWithRoleCheckController < Doorkeeper::AuthorizationsController
     def new
-      # current_resource_owner == current_user
-      # server.client_via_uid.application == OAuth::Applications
       if resource_owner_has_role_for_application?
         super
       else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   use_doorkeeper do
     # it accepts :authorizations, :tokens, :applications and :authorized_applications
-    controllers :authorizations => 'doorkeeper/authorizations_with_role_check'
+    controllers authorizations: "doorkeeper/authorizations_with_role_check"
   end
   devise_for :users, skip: [:registrations]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  use_doorkeeper
+  use_doorkeeper do
+    # it accepts :authorizations, :tokens, :applications and :authorized_applications
+    controllers :authorizations => 'doorkeeper/authorizations_with_role_check'
+  end
   devise_for :users, skip: [:registrations]
 
   resources :users, only: [:edit, :update]

--- a/spec/requests/doorkeeper/authorization_spec.rb
+++ b/spec/requests/doorkeeper/authorization_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe "GET /oauth/authorize" do
   end
 
   def authorize_url
-    "/oauth/authorize?client_id=#{doorkeeper_app.uid}&redirect_uri=#{doorkeeper_app.redirect_uri}&response_type=code&state=c987b113ab6ea39c642f712ba587e8975c05d4fa7bd36fd7"
+    oauth_authorization_url(
+      client_id: doorkeeper_app.uid,
+      redirect_uri: doorkeeper_app.redirect_uri,
+      response_type: "code",
+      state: "c987b113ab6ea39c642f712ba587e8975c05d4fa7bd36fd7"
+    )
   end
 
   context "when the resource owner (User)" do

--- a/spec/requests/doorkeeper/authorization_spec.rb
+++ b/spec/requests/doorkeeper/authorization_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "GET /oauth/authorize" do
       client_id: doorkeeper_app.uid,
       redirect_uri: doorkeeper_app.redirect_uri,
       response_type: "code",
-      state: "c987b113ab6ea39c642f712ba587e8975c05d4fa7bd36fd7"
+      state: "TEST_VALUE"
     )
   end
 

--- a/spec/requests/doorkeeper/authorization_spec.rb
+++ b/spec/requests/doorkeeper/authorization_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "GET /oauth/authorize" do
+  include Warden::Test::Helpers
+
+  let!(:doorkeeper_app) { create :doorkeeper_application, redirect_uri: "https://localhost:34343/auth/callback" }
+  let!(:resource_owner) { create :user }
+
+  before do
+    Warden.test_mode!
+    login_as(resource_owner, scope: :user)
+  end
+
+  def authorize_url
+    "/oauth/authorize?client_id=#{doorkeeper_app.uid}&redirect_uri=#{doorkeeper_app.redirect_uri}&response_type=code&state=c987b113ab6ea39c642f712ba587e8975c05d4fa7bd36fd7"
+  end
+
+  context "when the resource owner (User)" do
+    context "as a role for the application" do
+      it "redirects to the apps auth callback uri" do
+        create :permission, user: resource_owner, application: doorkeeper_app
+
+        get authorize_url
+
+        # all we want to check is the redirect goes to the redirect_uri
+        # not whether the code and state params are correct
+        response_redirect_uri = URI.parse response.headers["Location"]
+        response_redirect_uri.query = nil
+
+        expect(response_redirect_uri.to_s).to eq(doorkeeper_app.redirect_uri)
+      end
+    end
+
+    context "has no role for the application" do
+      it "redirects to the apps auth failure uri" do
+        get authorize_url
+        expect(response).to redirect_to("https://localhost:34343/auth/failure?message=unauthorized")
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Check that user has a role for the application they are logging into before issuing an oauth code to the consuming application

Will redirect the user to the auth/failure url on the consuming app (assumes ```/auth/failure``` https://github.com/intridea/omniauth/blob/master/lib/omniauth/failure_endpoint.rb)

Finishes https://www.pivotaltracker.com/story/show/89526616

**Don't merge until the below pull requests have been merged:**
* https://github.com/ministryofjustice/defence-request-service/pull/143
* https://github.com/ministryofjustice/defence-request-service-rota/pull/35
