### PR TITLE
Allow options to be passed to profiles and organisations endpoints

### DIFF
--- a/drs-auth_client/lib/drs/auth_client/client.rb
+++ b/drs-auth_client/lib/drs/auth_client/client.rb
@@ -13,13 +13,13 @@ module Drs
         @auth_token = auth_token
       end
 
-      def get(path, options = {})
+      def get(path, params = {})
         raise Errors::Unauthorised if @auth_token.blank?
 
         response = conn.get do |request|
           request.url path
           request.headers["Authorization"] = "Bearer #{@auth_token}"
-          request.params = options
+          request.params = params
         end
 
         process_response(response)
@@ -32,16 +32,16 @@ module Drs
         get_resource("organisations/#{id}", Models::Organisation, :from_hash, nil)
       end
 
-      def organisations(options = {})
-        get_resource("organisations", Models::Organisation, :collection_from_hash, [], options)
+      def organisations(params = {})
+        get_resource("organisations", Models::Organisation, :collection_from_hash, [], params)
       end
 
       def profile(id)
         get_resource("profiles/#{id}", Models::Profile, :from_hash, nil)
       end
 
-      def profiles(options = {})
-        get_resource("profiles", Models::Profile, :collection_from_hash, [], options)
+      def profiles(params = {})
+        get_resource("profiles", Models::Profile, :collection_from_hash, [], params)
       end
 
       private
@@ -63,8 +63,8 @@ module Drs
         JSON.parse(response).deep_symbolize_keys
       end
 
-      def get_resource(path, model, model_method, default_result, options = {})
-        response = get(path, options)
+      def get_resource(path, model, model_method, default_result, params = {})
+        response = get(path, params)
         if response
           model.send(model_method, parse_response(response))
         else

--- a/drs-auth_client/lib/drs/auth_client/client.rb
+++ b/drs-auth_client/lib/drs/auth_client/client.rb
@@ -13,12 +13,13 @@ module Drs
         @auth_token = auth_token
       end
 
-      def get(path)
+      def get(path, options = {})
         raise Errors::Unauthorised if @auth_token.blank?
 
         response = conn.get do |request|
           request.url path
           request.headers["Authorization"] = "Bearer #{@auth_token}"
+          request.params = options
         end
 
         process_response(response)
@@ -31,16 +32,16 @@ module Drs
         get_resource("organisations/#{id}", Models::Organisation, :from_hash, nil)
       end
 
-      def organisations
-        get_resource("organisations", Models::Organisation, :collection_from_hash, [])
+      def organisations(options = {})
+        get_resource("organisations", Models::Organisation, :collection_from_hash, [], options)
       end
 
       def profile(id)
         get_resource("profiles/#{id}", Models::Profile, :from_hash, nil)
       end
 
-      def profiles
-        get_resource("profiles", Models::Profile, :collection_from_hash, [])
+      def profiles(options = {})
+        get_resource("profiles", Models::Profile, :collection_from_hash, [], options)
       end
 
       private
@@ -62,8 +63,8 @@ module Drs
         JSON.parse(response).deep_symbolize_keys
       end
 
-      def get_resource(path, model, model_method, default_result)
-        response = get(path)
+      def get_resource(path, model, model_method, default_result, options = {})
+        response = get(path, options)
         if response
           model.send(model_method, parse_response(response))
         else

--- a/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
+++ b/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
@@ -83,6 +83,25 @@ RSpec.shared_examples "available resource" do |name|
         is_expected.to eql([])
       end
     end
+
+    context "with options" do
+      let(:options) { { key: "value" } }
+      let(:path) { "#{path_prefix}?key=value" }
+      let(:response_hash) { Hash[collection_hash_prefix, [{uid: "UID 7", other: "NAME 7"}]] }
+      let(:response_body) { -> (_) {response_hash.to_json} }
+
+      subject { client.send(collection_resource_method, options) }
+
+      it "makes the correct request with params" do
+        subject
+
+        stubbed_calls.verify_stubbed_calls
+      end
+
+      it "returns only matching #{plural_name}" do
+        expect(subject.map(&:uid)).to match_array(["UID 7"])
+      end
+    end
   end
 
 end

--- a/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
+++ b/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
@@ -84,11 +84,11 @@ RSpec.shared_examples "available resource" do |name|
       end
     end
 
-    context "with options" do
-      let(:options) { { key: "value" } }
+    context "with params" do
+      let(:params) { { key: "value" } }
       let(:path) { "#{path_prefix}?key=value" }
 
-      subject { client.send(collection_resource_method, options) }
+      subject { client.send(collection_resource_method, params) }
 
       it "makes the correct request with params" do
         subject

--- a/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
+++ b/drs-auth_client/spec/lib/drs/auth_client/client_spec.rb
@@ -87,8 +87,6 @@ RSpec.shared_examples "available resource" do |name|
     context "with options" do
       let(:options) { { key: "value" } }
       let(:path) { "#{path_prefix}?key=value" }
-      let(:response_hash) { Hash[collection_hash_prefix, [{uid: "UID 7", other: "NAME 7"}]] }
-      let(:response_body) { -> (_) {response_hash.to_json} }
 
       subject { client.send(collection_resource_method, options) }
 
@@ -96,10 +94,6 @@ RSpec.shared_examples "available resource" do |name|
         subject
 
         stubbed_calls.verify_stubbed_calls
-      end
-
-      it "returns only matching #{plural_name}" do
-        expect(subject.map(&:uid)).to match_array(["UID 7"])
       end
     end
   end


### PR DESCRIPTION
* Pass optional `options` hash to `organisations` and `profiles` methods and append them as query params