### PR TITLE
Remove admin user and add laa users in seeds

### DIFF
--- a/db/seeds/organisations.rb
+++ b/db/seeds/organisations.rb
@@ -19,19 +19,29 @@ law_firm = Organisation.where(slug: "law-firm").first_or_create(
   organisation_type: "law_firm"
 )
 
+laa = Organisation.where(slug: "laa").first_or_create(
+  name: "Legal Aid Agency",
+  organisation_type: "civil",
+)
+
 (1..5).each do |i|
   Membership.create(
     organisation: custody_suite,
-    profile: Profile.where(email: "cso#{i}@example.com").first,
+    profile: Profile.where(email: "cso#{i}@example.com").first
   )
 
   Membership.create(
     organisation: call_centre,
-    profile: Profile.where(email: "cco#{i}@example.com").first,
+    profile: Profile.where(email: "cco#{i}@example.com").first
   )
 
   Membership.create(
     organisation: law_firm,
-    profile: Profile.where(email: "solicitor#{i}@example.com").first,
+    profile: Profile.where(email: "solicitor#{i}@example.com").first
+  )
+
+  Membership.create(
+    organisation: laa,
+    profile: Profile.where(email: "laa#{i}@example.com").first
   )
 end

--- a/db/seeds/roles-permissions.rb
+++ b/db/seeds/roles-permissions.rb
@@ -1,19 +1,10 @@
-role = Role.where(name: "admin").first_or_create
 cso_role = Role.where(name: "cso").first_or_create
 cco_role = Role.where(name: "cco").first_or_create
 solicitor_role = Role.where(name: "solicitor").first_or_create
+laa_role = Role.where(name: "laa").first_or_create
 
 rota_app = Doorkeeper::Application.find_by(name: "Rota")
 service_app = Doorkeeper::Application.find_by(name: "Service")
-
-Permission.where(role: role,
-                 user: User.where(email: "user2@example.com").first,
-                 application: service_app,
-                 organisation: Organisation.where(slug: "example-org".first)).first_or_create
-Permission.where(role: role,
-                 user: User.where(email: "user2@example.com").first,
-                 application: rota_app,
-                 organisation: Organisation.where(slug: "example-org".first)).first_or_create
 
 (1..5).each do |i|
   Permission.where(role: cso_role,
@@ -32,5 +23,11 @@ Permission.where(role: role,
                    user: User.where(email: "solicitor#{i}@example.com").first,
                    application: service_app,
                    organisation: Organisation.where(slug: "law-firm").first
+                  ).first_or_create
+
+  Permission.where(role: laa_role,
+                   user: User.where(email: "laa#{i}@example.com").first,
+                   application: rota_app,
+                   organisation: Organisation.where(slug: "laa")
                   ).first_or_create
 end

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -45,4 +45,14 @@ Profile.where(user: user2).first_or_create(
     tel: "01234567890",
     mobile: "07123456789"
   )
+
+  laa = User.where(email: "laa#{i}@example.com").first_or_create(password: "password")
+  Profile.where(user: laa).first_or_create(
+    name: "LAA #{i}",
+    address: "#{i} Fake Street",
+    postcode: "POSTCODE",
+    email: "laa#{i}@example.com",
+    tel: "09011105010",
+    mobile: "07123456789"
+  )
 end


### PR DESCRIPTION
No apps implement the admin role, so there is no need for it. 

We also need to specify *some* role for users logging in to the rota app or their authentication will fail.