### PR TITLE
Remove permission from Organisation detail page

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -23,9 +23,9 @@ class PermissionsController < ApplicationController
 
   def destroy
     if @permission.destroy
-      redirect_to permissions_path, notice: flash_message(:destroy, Permission)
+      redirect_to_supplied_path_or permissions_path, notice: flash_message(:destroy, Permission)
     else
-      redirect_to permissions_path, notice: flash_message(:failed_destroy, Permission)
+      redirect_to_supplied_path_or permissions_path, notice: flash_message(:failed_destroy, Permission)
     end
   end
 
@@ -43,7 +43,7 @@ class PermissionsController < ApplicationController
                   :organisation_id)
   end
 
-  def redirect_to_supplied_path_or other_path, *args
+  def redirect_to_supplied_path_or(other_path, *args)
     redirect_to (params[:redirect_path] || other_path), *args
   end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -10,4 +10,6 @@ class Permission < ActiveRecord::Base
   scope :for_application, ->(application) {
     where(application: application)
   }
+
+  delegate :name, to: :organisation, prefix: true, allow_nil: true
 end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -78,7 +78,10 @@
             <dl>
               <%- profile.user.permissions.order(:application_id).each do |permission| %>
                 <dt><%= permission.application.name %> App:</dt>
-                <dd><%= permission.role.name%></dd>
+                <dd>
+                  <%= permission.role.name %>
+                  <%= link_to t(:delete), permission_path(permission, redirect_path: organisation_path(@organisation)), method: :delete, data: { confirm: t(:are_you_sure)} %>
+                </dd>
               <%- end %>
             </dl>
             <%- end %>

--- a/app/views/permissions/index.html.erb
+++ b/app/views/permissions/index.html.erb
@@ -13,7 +13,7 @@
         <td><%= permission.user.email %></td>
         <td><%= permission.role.name %></td>
         <td><%= permission.application.name %></td>
-        <td><%= permission.organisation.name %></td>
+        <td><%= permission.organisation_name %></td>
         <td><%= link_to t("delete"), permission, method: :delete, data: { confirm: t('are_you_sure') } %></td>
       </tr>
     <% end %>

--- a/spec/features/permission_management_spec.rb
+++ b/spec/features/permission_management_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe "Users managing permissions" do
     expect(page).to have_content "Permission successfully deleted"
   end
 
+  specify "can delete permissions from the organisation show page"  do
+    visit organisation_path(organisation)
+
+    within "##{organisation.profiles.first.id}-row" do
+      within "dl" do
+        click_link "Delete"
+      end
+    end
+
+    expect(page).to have_content "Permission successfully deleted"
+    expect(page).not_to have_content permission.application.name
+  end
+
   specify "are shown a message if the permission cannot be deleted"  do
     visit permissions_path
 


### PR DESCRIPTION
Allows the removal of permissions for a user from the same view where they can be added on the Organisation show page:


![screen shot 2015-05-06 at 17 18 45](https://cloud.githubusercontent.com/assets/722405/7497704/232e903e-f414-11e4-879b-5fdea1b5e959.png)
