### PR TITLE
[make_seed_failures_raise_errors] Make seed failures raise errors

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,7 @@
 class Organisation < ActiveRecord::Base
   ORGANISATION_TYPES = %w{
     call_centre
+    civil
     court
     custody_suite
     law_firm

--- a/db/seeds/applications.rb
+++ b/db/seeds/applications.rb
@@ -1,11 +1,11 @@
-rota_oauth_app = Doorkeeper::Application.where(name: "Rota").first_or_create(
+rota_oauth_app = Doorkeeper::Application.where(name: "Rota").first_or_create!(
   uid: ENV.fetch("ROTA_UID"),
   secret: ENV.fetch("ROTA_SECRET"),
   redirect_uri: ENV.fetch("ROTA_REDIRECT_URI"))
-GovernmentApplication.where(oauth_application: rota_oauth_app).first_or_create
+GovernmentApplication.where(oauth_application: rota_oauth_app).first_or_create!
 
-service_oauth_app = Doorkeeper::Application.where(name: "Service").first_or_create(
+service_oauth_app = Doorkeeper::Application.where(name: "Service").first_or_create!(
   uid: ENV.fetch("SERVICE_UID"),
   secret: ENV.fetch("SERVICE_SECRET"),
   redirect_uri: ENV.fetch("SERVICE_REDIRECT_URI"))
-GovernmentApplication.where(oauth_application: service_oauth_app).first_or_create
+GovernmentApplication.where(oauth_application: service_oauth_app).first_or_create!

--- a/db/seeds/organisations.rb
+++ b/db/seeds/organisations.rb
@@ -1,25 +1,25 @@
-example_org = Organisation.where(slug: "example-org").first_or_create(
+example_org = Organisation.where(slug: "example-org").first_or_create!(
   name: "Example Org",
   organisation_type: "law_office")
 
 Membership.create(organisation: example_org, profile: Profile.where(email: "jeff@example").first)
 
-custody_suite = Organisation.where(slug: "custody-suite").first_or_create(
+custody_suite = Organisation.where(slug: "custody-suite").first_or_create!(
   name: "Custody Suite",
   organisation_type: "custody_suite"
 )
 
-call_centre = Organisation.where(slug: "capita").first_or_create(
+call_centre = Organisation.where(slug: "capita").first_or_create!(
   name: "Capita",
   organisation_type: "call_centre"
 )
 
-law_firm = Organisation.where(slug: "law-firm").first_or_create(
+law_firm = Organisation.where(slug: "law-firm").first_or_create!(
   name: "Law Firm",
   organisation_type: "law_firm"
 )
 
-laa = Organisation.where(slug: "laa").first_or_create(
+laa = Organisation.where(slug: "laa").first_or_create!(
   name: "Legal Aid Agency",
   organisation_type: "civil",
 )

--- a/db/seeds/roles-permissions.rb
+++ b/db/seeds/roles-permissions.rb
@@ -1,7 +1,7 @@
-cso_role = Role.where(name: "cso").first_or_create
-cco_role = Role.where(name: "cco").first_or_create
-solicitor_role = Role.where(name: "solicitor").first_or_create
-laa_role = Role.where(name: "laa").first_or_create
+cso_role = Role.where(name: "cso").first_or_create!
+cco_role = Role.where(name: "cco").first_or_create!
+solicitor_role = Role.where(name: "solicitor").first_or_create!
+laa_role = Role.where(name: "laa").first_or_create!
 
 rota_app = Doorkeeper::Application.find_by(name: "Rota")
 service_app = Doorkeeper::Application.find_by(name: "Service")

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,23 +1,24 @@
 # Test user
-User.where(email: "user@example.com").first_or_create(
+User.where(email: "user@example.com").first_or_create!(
   email: "user@example.com", password: "password")
 
 # Test user with a profile assocaited
-user2 = User.where(email: "user2@example.com").first_or_create(
+user2 = User.where(email: "user2@example.com").first_or_create!(
   email: "user2@example.com", password: "password")
 
-Profile.where(user: user2).first_or_create(
+Profile.where(user: user2).first_or_create!(
   name: "Jeff",
   address: "123 Fake Street",
   postcode: "POSTCODE",
   email: "jeff@example.com",
   tel: "09011105010",
+  mobile: "07123456789"
 )
 
 # Create 5 CSOs, CCOs, and solicitors
 (1..5).each do |i|
-  cso = User.where(email: "cso#{i}@example.com").first_or_create(password: "password")
-  Profile.where(user: cso).first_or_create(
+  cso = User.where(email: "cso#{i}@example.com").first_or_create!(password: "password")
+  Profile.where(user: cso).first_or_create!(
     name: "CSO ##{i}",
     address: "#{i} Fake Street",
     postcode: "POSTCODE",
@@ -26,8 +27,8 @@ Profile.where(user: user2).first_or_create(
     mobile: "07123456789"
   )
 
-  cco = User.where(email: "cco#{i}@example.com").first_or_create(password: "password")
-  Profile.where(user: cco).first_or_create(
+  cco = User.where(email: "cco#{i}@example.com").first_or_create!(password: "password")
+  Profile.where(user: cco).first_or_create!(
     name: "CCO ##{i}",
     address: "#{i} Fake Street",
     postcode: "POSTCODE",
@@ -36,8 +37,8 @@ Profile.where(user: user2).first_or_create(
     mobile: "07123456789"
   )
 
-  solicitor = User.where(email: "solicitor#{i}@example.com").first_or_create(password: "password")
-  Profile.where(user: solicitor).first_or_create(
+  solicitor = User.where(email: "solicitor#{i}@example.com").first_or_create!(password: "password")
+  Profile.where(user: solicitor).first_or_create!(
     name: "Solicitor ##{i}",
     address: "#{i} Fake Street",
     postcode: "POSTCODE",
@@ -46,8 +47,8 @@ Profile.where(user: user2).first_or_create(
     mobile: "07123456789"
   )
 
-  laa = User.where(email: "laa#{i}@example.com").first_or_create(password: "password")
-  Profile.where(user: laa).first_or_create(
+  laa = User.where(email: "laa#{i}@example.com").first_or_create!(password: "password")
+  Profile.where(user: laa).first_or_create!(
     name: "LAA #{i}",
     address: "#{i} Fake Street",
     postcode: "POSTCODE",

--- a/spec/features/organisation_management_spec.rb
+++ b/spec/features/organisation_management_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature "Users managing organisations" do
     expect(page).to have_select("Organisation type",
                                 options: ["-- Select an organisation type --",
                                           "Call centre",
+                                          "Civil",
                                           "Court",
                                           "Custody suite",
                                           "Law firm",


### PR DESCRIPTION
Currently seed failures generate no error output, which makes failed environment builds difficult to detect.

We now raise errors if a seed fails to save

**NOTES**

Please check my changes in app/models/organisation.rb - which makes https://github.com/ministryofjustice/defence-request-service-auth/blob/master/db/seeds/organisations.rb#L24 work.

Please note that I've *not* made similar changes to https://github.com/ministryofjustice/defence-request-service-auth/blob/master/db/seeds/roles-permissions.rb#L10-L33 because these cause errors on a re-run. That probably needs fixing too