### PR TITLE
[jenkins_builds] Changing Builds to run on Jenkins instead of CircleCI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@ coverage/*
 
 # Remove Makefile, which changes often when re-running
 Makefile
+
+# This is created at runtime through the Dockerfile, and should be ignored
+.git-revision

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # The Dockerfile is copied from docker/... to Dockerfile during builds via Makefile, since we can't
 # use the -f option to Docker (CircleCI's docker version is too old)
 /Dockerfile
+
+# This is created by docker builds, and reflects the current git repo status
+.git-revision

--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,31 @@ base_container:
 
 development_container: base_container
 	cat docker/Dockerfile-development | sed -e "s/FROM ${DOCKER_IMAGE}:base_localbuild/FROM ${DOCKER_IMAGE}:base_${DOCKER_IMAGE_TAG}/g" > Dockerfile
+
+	# Store the repo offset into the Dockerfile. We do this as the very last
+	# step of each container (not the Base container) to avoid invalidating caching.
+	printf "\nRUN echo `git rev-parse HEAD` > .git-revision\n\n" >> Dockerfile
+
 	docker build -t "${DOCKER_IMAGE}:development_${DOCKER_IMAGE_TAG}" .
 	rm -f Dockerfile
 
 production_container: base_container
 	cat docker/Dockerfile-production | sed -e "s/FROM ${DOCKER_IMAGE}:base_localbuild/FROM ${DOCKER_IMAGE}:base_${DOCKER_IMAGE_TAG}/g" > Dockerfile
+
+	# Store the repo offset into the Dockerfile. We do this as the very last
+	# step of each container (not the Base container) to avoid invalidating caching.
+	printf "\nRUN echo `git rev-parse HEAD` > .git-revision\n\n" >> Dockerfile
+
 	docker build -t "${DOCKER_IMAGE}:production_${DOCKER_IMAGE_TAG}" .
 	rm -f Dockerfile
 
 test_container: base_container
 	cat docker/Dockerfile-test | sed -e "s/FROM ${DOCKER_IMAGE}:base_localbuild/FROM ${DOCKER_IMAGE}:base_${DOCKER_IMAGE_TAG}/g" > Dockerfile
+
+	# Store the repo offset into the Dockerfile. We do this as the very last
+	# step of each container (not the Base container) to avoid invalidating caching.
+	printf "\nRUN echo `git rev-parse HEAD` > .git-revision\n\n" >> Dockerfile
+
 	docker build -t "${DOCKER_IMAGE}:test_${DOCKER_IMAGE_TAG}" .
 	rm -f Dockerfile
 


### PR DESCRIPTION
* Integrated .git-revision file which contains info on the SHA when the build
  was run.