### PR TITLE
[add_ping_response] Add status controller for pings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,6 @@ base_container:
 development_container: base_container
 	cat docker/Dockerfile-development | sed -e "s/FROM ${DOCKER_IMAGE}:base_localbuild/FROM ${DOCKER_IMAGE}:base_${DOCKER_IMAGE_TAG}/g" > Dockerfile
 
-	# Store the repo offset into the Dockerfile. We do this as the very last
-	# step of each container (not the Base container) to avoid invalidating caching.
-	printf "\nRUN echo `git rev-parse HEAD` > /.git-revision\n\n" >> Dockerfile
-
 	docker build -t "${DOCKER_IMAGE}:development_${DOCKER_IMAGE_TAG}" .
 	rm -f Dockerfile
 
@@ -58,10 +54,6 @@ production_container: base_container
 
 test_container: base_container
 	cat docker/Dockerfile-test | sed -e "s/FROM ${DOCKER_IMAGE}:base_localbuild/FROM ${DOCKER_IMAGE}:base_${DOCKER_IMAGE_TAG}/g" > Dockerfile
-
-	# Store the repo offset into the Dockerfile. We do this as the very last
-	# step of each container (not the Base container) to avoid invalidating caching.
-	printf "\nRUN echo `git rev-parse HEAD` > /.git-revision\n\n" >> Dockerfile
 
 	docker build -t "${DOCKER_IMAGE}:test_${DOCKER_IMAGE_TAG}" .
 	rm -f Dockerfile

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,26 @@
+require_relative "../../lib/ping_response"
+
+class StatusController < ApplicationController
+  skip_before_filter :authenticate_user!
+
+  def index
+    respond_to do |format|
+      format.json { render json: {"status" => "OK"} }
+      format.xml { render xml: {"Status" => "OK"}.to_xml(root: "Response") }
+      format.any { render text: "OK"}
+    end
+  end
+
+  def ping
+    # If there's a problem, we need to return an error 500
+    ping_response = PingResponse.new
+
+    status = ping_response.ok? ? :ok : :error
+
+    respond_to do |format|
+      # When debugging problems at 3am, support staff might not specify the JSON
+      # content type. We return JSON in all cases.
+      format.all { render json: ping_response.data, status: status }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
   end
 
   get "/status" => "status#index"
+  get "/ping" => "status#ping"
+
   get "/help", controller: :static, action: :help, as: :help
   get "/maintenance", controller: :static, action: :maintenance, as: :maintenance
   get "/cookies", controller: :static, action: :cookies, as: :cookies

--- a/lib/ping_response.rb
+++ b/lib/ping_response.rb
@@ -1,0 +1,23 @@
+class PingResponse
+  VERSION_FILE = "/.version.yml"
+
+  UNKNOWN_VERSION_DATA_RESPONSE = {
+    version_number: "unknown",
+    build_date: nil,
+    commit_id: "unknown",
+    build_tag: "unknown"
+  }
+
+  attr_reader :ok, :data
+  alias :ok? :ok
+
+  def initialize
+    begin
+      @data = YAML.load_file(VERSION_FILE)
+      @ok = true
+    rescue
+      @data = UNKNOWN_VERSION_DATA_RESPONSE
+      @ok = false
+    end
+  end
+end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe StatusController, type: :controller do
+
+  describe "GET index" do
+    it "returns 200 status code" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "HTML request" do
+      it "returns OK in body" do
+        get :index
+        expect(response.body).to include("OK")
+      end
+    end
+
+    context "JSON request" do
+      it "returns a JSON status :ok" do
+        get :index, format: "json"
+        expect(JSON.parse response.body.strip).to eq({"status" => "OK"})
+      end
+    end
+
+    context "XML request" do
+      it "returns a XML status :ok" do
+        get :index, format: "xml"
+        expect(response.body.strip).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Status>OK</Status>\n</Response>")
+      end
+    end
+
+    context "other MIME type" do
+      it "returns OK in body" do
+        get :index, format: "text"
+        expect(response.body).to include("OK")
+      end
+    end
+  end
+
+  describe "GET /ping" do
+    context "with a failing request" do
+      it "returns 500 status codes for situations where an error occurs" do
+        expect_any_instance_of(PingResponse).to receive(:ok?).and_return(false)
+
+        get :ping
+        expect(response).to have_http_status(:error)
+      end
+    end
+
+    context "with a valid config setup" do
+      let(:fake_response) { { irrelevant_data: "irrelevant_response" }.with_indifferent_access }
+
+      before :each do
+        allow_any_instance_of(PingResponse).to receive(:ok?).and_return(true)
+        allow_any_instance_of(PingResponse).to receive(:data).and_return(fake_response)
+      end
+
+      it "returns an :ok status code for json requests" do
+        get :ping, format: "json"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the expected JSON result" do
+        get :ping, format: "json"
+        expect(JSON.parse response.body.strip).to eq(fake_response)
+      end
+
+      it "returns an :ok status code for non-json requests" do
+        get :ping, format: "html"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/lib/ping_response_spec.rb
+++ b/spec/lib/ping_response_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "tempfile"
+require_relative "../../lib/ping_response"
+
+RSpec.describe PingResponse do
+  let(:valid_version_file_content) {
+    { version_number: "1.23", build_date: Time.now, commit_id: "irrelevant sha", build_tag: "irrelevant build tag" }
+  }
+
+  let(:unknown_version_response) {
+    { version_number: "unknown", build_date: nil, commit_id: "unknown", build_tag: "unknown" }
+  }
+
+  let(:overridden_version_file) do
+    filehandle = Tempfile.new("ping_response")
+
+    filehandle.write(valid_version_file_content.to_yaml)
+    filehandle.close
+
+    filehandle.path
+  end
+
+  context "with a valid version file" do
+    describe ".ok?" do
+      it "should return a true value" do
+        stub_const("PingResponse::VERSION_FILE", overridden_version_file)
+        expect(subject.ok?).to be true
+      end
+    end
+
+    describe ".data" do
+      it "should return a valid set of data" do
+        stub_const("PingResponse::VERSION_FILE", overridden_version_file)
+
+        expect(subject.data).to eq(valid_version_file_content)
+      end
+    end
+  end
+
+  context "without a valid version file" do
+    describe ".data" do
+      it "returns an unknown_version_response" do
+        expect(YAML).to receive(:load_file).and_raise(StandardError)
+
+        expect(subject.data).to eq(unknown_version_response)
+      end
+    end
+
+    describe ".ok?" do
+      it "should return a false value" do
+        stub_const("PingResponse::VERSION_FILE", "/non-existent-file")
+        expect(subject.ok?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
As per https://github.com/ministryofjustice/defence-request-service/pull/179

Cleaned up some old cases of writing .git-revision file - which is replaced with /.version.yml 