### PR TITLE
[force_ssl_bugfix] Corrected the setting name for force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = Settings.force_ssl
+  config.force_ssl = Settings.rails.force_ssl
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
The environment variable wasn't being honored by rails, and was defaulting to false.