### PR TITLE
Stop AuthAPI returning all results incorrectly

### DIFF
--- a/drs-auth_client/lib/drs/auth_client/client.rb
+++ b/drs-auth_client/lib/drs/auth_client/client.rb
@@ -64,6 +64,8 @@ module Drs
       end
 
       def get_resource(path, model, model_method, default_result, params = {})
+        return default_result if params.values.any?(&:empty?)
+
         response = get(path, params)
         if response
           model.send(model_method, parse_response(response))


### PR DESCRIPTION
When passed an empty array of uids or organisations to retrieve, the AuthAPI was returning all of the entries for organisations.

This is due to a request being formed with a filtering key (uid or type) but the value pointing to an empty array. Since requests of this type have the key stripped out, there is no way to correctly distinguish them
from a properly formed request to list all of the organisations. In `Api::V1::OrganisationsController#find_organisations`, we always return a scope of records in order to support lookup operations. With no distinction between correctly formed and incorrectly formed requests, the API would return the full list of records.

This PR addresses the issue by implementing a short-circuiting method in the client gem, stopping any incorrectly formed requests from actually being made.