### PR TITLE
[clean_up_true_false_yaml_handling] Simplified true/false handling in Yaml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,5 +26,5 @@ action_mailer:
     password: <%= ENV.fetch('MAILER_SMTP_PASSWORD') %>
     enable_starttls_auto: true
 
-sandbox_email: <%= ENV.fetch('SANDBOX_EMAIL', 'false') == 'true' %>
+sandbox_email: <%= ENV.fetch('SANDBOX_EMAIL', 'false') %>
 sandbox_email_address: <%= ENV.fetch('SANDBOX_EMAIL_ADDRESS', nil) %>


### PR DESCRIPTION
The ERB code would place the string true/false in the YAML. When the YAML is
then parsed, the true/false is evaluated as an actual true/false, rather than a
string containing "true" or "false".

We thus do not need to check the string equivalent value in the yaml