### PR TITLE
Include organisations in credentials call

### DIFF
--- a/app/serializers/credentials_serializer.rb
+++ b/app/serializers/credentials_serializer.rb
@@ -40,7 +40,7 @@ class CredentialsSerializer
           uid: organisation.uid,
           name: organisation.name,
           type: organisation.organisation_type,
-          roles: membership.roles
+          roles: membership.roles & @application.available_role_names
       }
     end
   end

--- a/app/serializers/credentials_serializer.rb
+++ b/app/serializers/credentials_serializer.rb
@@ -9,8 +9,7 @@ class CredentialsSerializer
 
   def serialize
     {
-      user: serialized_user,
-      roles: serialized_roles,
+      user: serialized_user
     }
   end
 
@@ -31,10 +30,6 @@ class CredentialsSerializer
       organisations: serialized_organisations,
       uid: user.uid,
     }
-  end
-
-  def serialized_roles
-    user.role_names_for(application: application)
   end
 
   def serialized_organisations

--- a/app/serializers/credentials_serializer.rb
+++ b/app/serializers/credentials_serializer.rb
@@ -28,12 +28,25 @@ class CredentialsSerializer
         full_address: user.address,
         postcode: user.postcode,
       },
-      organisation_uids: user.organisations.pluck(:uid),
+      organisations: serialized_organisations,
       uid: user.uid,
     }
   end
 
   def serialized_roles
     user.role_names_for(application: application)
+  end
+
+  def serialized_organisations
+    user.memberships.map do |membership|
+      organisation = membership.organisation
+
+      {
+          uid: organisation.uid,
+          name: organisation.name,
+          type: organisation.organisation_type,
+          roles: membership.roles
+      }
+    end
   end
 end

--- a/spec/factories/doorkeeper_application.rb
+++ b/spec/factories/doorkeeper_application.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :doorkeeper_application, class: "Doorkeeper::Application" do |application|
-    sequence(:name) {|i| "drs-auth" }
+    name "drs-auth"
     sequence(:uid) {|i| "#{i}" }
     sequence(:secret) {|i| "#{i}" }
     redirect_uri "https://example.com/oauth/callbacks"

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe "GET /api/v1/profiles/me" do
     include_context "logged in API User"
 
     it "returns a 200 response with the user credentials" do
+      roles = %w(admin lion_tamer)
       organisation = create :organisation
-      create :membership, user: user, organisation: organisation, permissions: { roles: ["admin"] }
+      create :membership, user: user, organisation: organisation, permissions: { roles: roles }
 
       get "/api/v1/me", nil, api_request_headers
 
@@ -24,10 +25,16 @@ RSpec.describe "GET /api/v1/profiles/me" do
               "full_address" => user.address,
               "postcode" => user.postcode,
             },
-            "organisation_uids" => user.organisations.map(&:uid),
+            "organisations" => [
+                {
+                    "uid" => organisation.uid,
+                    "name" => organisation.name,
+                    "type" => organisation.organisation_type,
+                    "roles" => roles
+                }
+            ],
             "uid" => user.uid
-          },
-          "roles" => ["admin"]
+          }
         }
       )
     end

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe "GET /api/v1/profiles/me" do
     include_context "logged in API User"
 
     it "returns a 200 response with the user credentials" do
-      roles = %w(admin lion_tamer)
-      organisation = create :organisation
+      application_roles = ["admin"]
+      roles = application_roles + ["lion_tamer"]
+      organisation = create :organisation, organisation_type: "custody_suite"
       create :membership, user: user, organisation: organisation, permissions: { roles: roles }
 
       get "/api/v1/me", nil, api_request_headers
@@ -30,7 +31,7 @@ RSpec.describe "GET /api/v1/profiles/me" do
                     "uid" => organisation.uid,
                     "name" => organisation.name,
                     "type" => organisation.organisation_type,
-                    "roles" => roles
+                    "roles" => application_roles
                 }
             ],
             "uid" => user.uid

--- a/spec/serializers/credentials_serializer_spec.rb
+++ b/spec/serializers/credentials_serializer_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe CredentialsSerializer do
   end
 
   describe "#serialize" do
-    let(:application) { build_stubbed :doorkeeper_application }
-    let(:roles) { %w(tea_drinker cake_eater) }
+    let(:application) { build_stubbed :doorkeeper_application, name: "drs-service" }
+    let(:application_roles) { %w(cso) }
 
     it "serializes the credentials for the passed in user" do
       organisation = create :organisation
       user = create :user
-      create :membership, user: user, organisation: organisation, permissions: { roles: roles }
+      create :membership, user: user, organisation: organisation, permissions: { roles: application_roles + [:cake_eater] }
 
       serializer = CredentialsSerializer.new user: user, application: application
       expect(serializer.serialize).to eq(
@@ -40,7 +40,7 @@ RSpec.describe CredentialsSerializer do
                     uid: organisation.uid,
                     name: organisation.name,
                     type: organisation.organisation_type,
-                    roles: roles
+                    roles: application_roles
                 }
             ],
             uid: user.uid

--- a/spec/serializers/credentials_serializer_spec.rb
+++ b/spec/serializers/credentials_serializer_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe CredentialsSerializer do
                 }
             ],
             uid: user.uid
-          },
-          roles: user.role_names_for(application: application)
+          }
         }
       )
     end

--- a/spec/serializers/credentials_serializer_spec.rb
+++ b/spec/serializers/credentials_serializer_spec.rb
@@ -15,16 +15,15 @@ RSpec.describe CredentialsSerializer do
   end
 
   describe "#serialize" do
-    let(:profile) { create :profile, :with_organisations }
     let(:application) { build_stubbed :doorkeeper_application }
-    let(:role) { build_stubbed :role }
-    let(:permission) { build_stubbed :permission, application: application, user: user, role: role }
+    let(:roles) { %w(tea_drinker cake_eater) }
 
     it "serializes the credentials for the passed in user" do
       organisation = create :organisation
-      user = create :user, organisations: [organisation]
-      serializer = CredentialsSerializer.new user: user, application: application
+      user = create :user
+      create :membership, user: user, organisation: organisation, permissions: { roles: roles }
 
+      serializer = CredentialsSerializer.new user: user, application: application
       expect(serializer.serialize).to eq(
         {
           user: {
@@ -36,7 +35,14 @@ RSpec.describe CredentialsSerializer do
               full_address: user.address,
               postcode: user.postcode,
             },
-            organisation_uids: user.organisations.map(&:uid),
+            organisations: [
+                {
+                    uid: organisation.uid,
+                    name: organisation.name,
+                    type: organisation.organisation_type,
+                    roles: roles
+                }
+            ],
             uid: user.uid
           },
           roles: user.role_names_for(application: application)


### PR DESCRIPTION
Requesting `/api/v1/me` now returns more details about each organisation and does not return global roles any more.