### PR TITLE
Redirect to sign in page after logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,8 @@ class ApplicationController < ActionController::Base
     flash[:alert] = t("not_authorized")
     redirect_to(request.referrer || root_path)
   end
+
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
 end


### PR DESCRIPTION
All other pages are protected by auth, this means
after logging out and hitting the homepage
(default redirect), you will be given a flash
message telling you to login in before continuing.

By redirecting straight to the sign in page, there
is no subsequent redirect and we can have a nice
"Signed out successfully" message