### PR TITLE
[asset_content_encoding] Revert to known-good fog-aws version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "coffee-rails", "~> 4.1.0"
 gem "devise", "~> 3.4.1"
 gem "doorkeeper"
 gem "email_validator"
+gem "fog-aws", "= 0.1.2"          # See https://github.com/fog/fog-aws/issues/130
 gem "jbuilder", "~> 2.0"
 gem "jquery-rails"
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.5.0)
+    fog-aws (0.1.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -455,6 +455,7 @@ DEPENDENCIES
   email_validator
   factory_girl_rails
   faker
+  fog-aws (= 0.1.2)
   govuk_elements_rails (~> 0.1.1)
   govuk_frontend_toolkit (~> 2.0.1)
   guard-rspec


### PR DESCRIPTION
The asset_sync gem uses fog-aws to upload assets to S3. However fog-aws > 0.1.2 sets the Content-Encoding to null value.

This gem can be removed once https://github.com/fog/fog-aws/issues/130 is correctly resolved