### PR TITLE
enable session timeouts for doorkeeper and devise

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -5,3 +5,4 @@ DEVISE_SALT=exampleSecretKey
 EMAIL_USERNAME=some_user_name
 EMAIL_PASSWORD=some_password
 SANDBOX_EMAIL=true
+SESSION_TIMEOUT_MINUTES=60

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem "quiet_assets", "~> 1.1"
   gem "rspec-rails", "~> 3.2.0"
   gem "rubocop", "~> 0.30"
+  gem "timecop"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.7.4)
     timers (4.0.1)
       hitimes
     tzinfo (1.2.2)
@@ -480,6 +481,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-matchers
   simplecov
+  timecop
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ## Environment Variables
 see .example.env
 
+### Session Timeout
+By default sessions will last 1 hour with no action before requiring the User to log in again.
+This can be customized by setting the ```SESSION_TIMEOUT_MINUTES``` ENV variable.
+(Note the value is in minutes)
+
 ## API documentation
 Written using API Blueprint syntax: https://apiblueprint.org/ into apiary.apib
 

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -10,12 +10,9 @@ module Api::V1
       User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
     end
 
+    # See https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/rails/helpers.rb
     def doorkeeper_unauthorized_render_options
-      {
-        json: {
-          errors: ["Not authorized, please login"]
-        }
-      }
+      { json: { errors: [doorkeeper_error.description] } }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,11 @@
 module ApplicationHelper
+
+  # Devise will add extra flash messages.
+  # We only want to display alerts, notices and errors
+  def flash
+    super.select {|key, _| key.to_s.in? ["alert", "notice", "error"] }
+  end
+
   def flash_messages
     capture do
       flash.each do |key, msg|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable
+  devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable, :timeoutable
 
   has_many :memberships, dependent: :destroy
   has_many :organisations, through: :memberships

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = Settings.devise.session_timeout.minutes
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -16,7 +16,7 @@ Doorkeeper.configure do
 
   # Access token expiration time (default 2 hours).
   # If you want to disable expiration, set this to nil.
-  # access_token_expires_in 2.hours
+  access_token_expires_in Settings.doorkeeper.session_timeout.minutes
 
   # Assign a custom TTL for implicit grants.
   # custom_access_token_expires_in do |oauth_client|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,9 +8,11 @@ rails:
 devise:
   key: <%= ENV.fetch('DEVISE_KEY') %>
   salt: <%= ENV.fetch('DEVISE_SALT') %>
+  session_timeout: <%= ENV.fetch('SESSION_TIMEOUT_MINUTES', 60) %>
 
 doorkeeper:
   force_ssl_in_redirect_uri: <%= ENV.fetch('FORCE_SSL_IN_REDIRECT_URI', true) %>
+  session_timeout: <%= ENV.fetch('SESSION_TIMEOUT_MINUTES', 60) %>
 
 action_mailer:
   default_url_options:

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
       after(:create) do |u, evaluator|
         (1..evaluator.number_of_applications).each do
           application = create :doorkeeper_application
-          create :access_token, application: application, resource_owner_id: u.id
+          create :access_token, application: application, resource_owner_id: u.id, expires_in: Settings.doorkeeper.session_timeout.minutes
         end
       end
     end

--- a/spec/features/users_session_timing_out_spec.rb
+++ b/spec/features/users_session_timing_out_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Users session timing out" do
+  let!(:user) { create(:user) }
+
+
+  specify "sessions remain active within the timeout period (#{Settings.devise.session_timeout} minutes)" do
+    user_is_logged_in user
+
+    Timecop.travel((Settings.devise.session_timeout - 2).minutes.from_now) do
+      visit "/"
+
+      expect(current_path).to eq("/")
+    end
+  end
+
+  specify "sessions expire after (#{Settings.devise.session_timeout} minutes) and require User to log in again" do
+    user_is_logged_in user
+
+    Timecop.travel((Settings.devise.session_timeout + 2).minutes.from_now) do
+      visit "/"
+
+      expect(current_path).to eq(new_user_session_path)
+      expect(page).to have_content("Your session expired. Please sign in again to continue.")
+    end
+  end
+end
+
+
+def user_is_logged_in(user)
+  visit new_user_session_path
+  fill_in "user_email", with: user.email
+  fill_in "user_password", with: user.password
+  click_button "Sign in"
+end

--- a/spec/requests/api/v1/credentials/show_spec.rb
+++ b/spec/requests/api/v1/credentials/show_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
-RSpec.describe "GET /api/v1/profiles/me" do
-  it_behaves_like "a protected endpoint", "/api/v1/profiles/me"
+RSpec.describe "GET /api/v1/me" do
+  it_behaves_like "a protected endpoint", "/api/v1/me"
 
   context "with a valid authentication token" do
     include_context "logged in API User"
+    it_behaves_like "an endpoint that times out sessions", "/api/v1/me"
 
     it "returns a 200 response with the user credentials" do
       application_roles = ["admin"]

--- a/spec/requests/api/v1/organisations/index_spec.rb
+++ b/spec/requests/api/v1/organisations/index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "GET /api/v1/organisations" do
 
   context "with a valid authentication token" do
     include_context "logged in API User"
+    it_behaves_like "an endpoint that times out sessions", "/api/v1/organisations"
 
     context "with no filtering parameters" do
       it "returns a 200 response with all organisations in name order" do

--- a/spec/requests/api/v1/organisations/show_spec.rb
+++ b/spec/requests/api/v1/organisations/show_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "GET /api/v1/organisations/:uid" do
 
   context "with a valid authentication token" do
     include_context "logged in API User"
+    it_behaves_like "an endpoint that times out sessions", "/api/v1/organisations/#{SecureRandom.uuid}"
 
     it "returns a 200 response with the requested organisation, and profiles in name order" do
       organisation = create :organisation

--- a/spec/requests/api/v1/users/index_spec.rb
+++ b/spec/requests/api/v1/users/index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "GET /api/v1/users" do
 
   context "with a valid authentication token" do
     include_context "logged in API User"
+    it_behaves_like "an endpoint that times out sessions", "/api/v1/users"
 
     context "with no filtering parameters" do
       it "returns a 200 response with all profiles in name order" do

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "GET /api/v1/profiles/:uid" do
+RSpec.describe "GET /api/v1/users/:uid" do
   it_behaves_like "a protected endpoint", "/api/v1/users/#{SecureRandom.uuid}"
 
   context "with a valid authentication token" do
     include_context "logged in API User"
+    it_behaves_like "an endpoint that times out sessions", "/api/v1/users/#{SecureRandom.uuid}"
 
-    it "returns a 200 response with the requested profile" do
+    it "returns a 200 response with the requested user" do
       organisation = create :organisation
       user = create :user, organisations: [organisation]
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -37,7 +37,7 @@ RSpec.shared_examples "an endpoint that times out sessions" do |url|
   it "returns a 401 response when the access_token has expired" do
     expect(token).not_to be_nil, "must supply a token in the spec scope"
 
-    Timecop.travel(3.hours.from_now) do
+    Timecop.travel((Settings.doorkeeper.session_timeout + 2).minutes.from_now) do
 
       get url, nil, api_request_headers
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -27,8 +27,26 @@ RSpec.shared_examples "a protected endpoint" do |url|
     expect(response.status).to eq(401)
     expect(response_json).to eq(
       {
-        "errors" => ["Not authorized, please login"]
+        "errors" => ["The access token is invalid"]
       }
     )
+  end
+end
+
+RSpec.shared_examples "an endpoint that times out sessions" do |url|
+  it "returns a 401 response when the access_token has expired" do
+    expect(token).not_to be_nil, "must supply a token in the spec scope"
+
+    Timecop.travel(3.hours.from_now) do
+
+      get url, nil, api_request_headers
+
+      expect(response.status).to eq(401)
+      expect(response_json).to eq(
+        {
+          "errors" => ["The access token expired"]
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
* default timeout period to 1 hour
* use the same timeout value for doorkeeper and devise so when doorkeeper responds with a 401 and the user is redirected to devise to login the devise session has also expired