### PR TITLE
[add_aws_region_env_var] Add AWS_REGION env variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -39,3 +39,5 @@ FORCE_SSL_IN_REDIRECT_URI=false
 # AWS and S3 settings
 # You can only push to AWS buckets from EC2 instances in the correct IAM role:
 AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+# Shoryuken requires this ENV variable to be called AWS_REGION
+AWS_REGION=eu-west-1

--- a/.env.test
+++ b/.env.test
@@ -39,3 +39,5 @@ ORGANISATION_FILE_PATH="spec/support/organisation_types.yml"
 # AWS and S3 settings
 # You can only push to AWS buckets from EC2 instances in the correct IAM role:
 AWS_S3_ASSET_BUCKET_NAME=cannot_push_to_aws_bucket_from_local_machine
+# Shoryuken requires this ENV variable to be called AWS_REGION
+AWS_REGION=eu-west-1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,7 +27,7 @@ action_mailer:
     enable_starttls_auto: true
 
 aws:
-  region: eu-west-1
+  region: <%= ENV.fetch("AWS_REGION") %>
   s3_asset_bucket_name: <%= ENV.fetch("AWS_S3_ASSET_BUCKET_NAME") %>
 
 sandbox_email: <%= ENV.fetch('SANDBOX_EMAIL', 'false') %>


### PR DESCRIPTION
Make projects consistent - AWS_REGION env var so that it can be used by Shoryuken and S3 asset_sync